### PR TITLE
Disable tarsnapper if configuration is omitted.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,4 +2,4 @@
 - include: tarsnapper.yml
   tags:
     - tarsnap
-  when: "{{ tarsnap_tarsnapper_conf }}"
+  when: "{{ tarsnap_tarsnapper_conf != None}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,1 +1,5 @@
 - include: tarsnap.yml tags=tarsnap
+- include: tarsnapper.yml
+  tags:
+    - tarsnap
+  when: "{{ tarsnap_tarsnapper_conf }}"

--- a/tasks/tarsnap.yml
+++ b/tasks/tarsnap.yml
@@ -67,28 +67,3 @@
 
 - name: Create Tarsnap cache directory
   file: state=directory path={{ tarsnap_cache }}
-
-- name: Install tarsnapper wrapper
-  easy_install: name=tarsnapper
-
-- name: Install tarsnapper configuration file
-  copy: src={{ tarsnap_tarsnapper_conf }} dest=/root/tarsnapper.conf mode=644
-
-- name: Install Tarsnap configuration file
-  template: src=tarsnaprc.j2 dest=/root/.tarsnaprc mode=644
-
-- name: Install tarsnapper backup script
-  copy: src=tarsnap.sh dest=/root/tarsnap.sh mode=755
-
-- name: Configure tarsnap logrotate
-  copy: src=etc_logrotate_tarsnap dest=/etc/logrotate.d/tarsnap owner=root group=root mode=0644
-
-- name: Install nightly Tarsnap-generations cronjob
-  cron:
-  args:
-    name: "Tarsnap backup"
-    job: "/root/tarsnap.sh > /dev/null"
-    minute: "{{ tarsnap_cron_minute }}"
-    hour: "{{ tarsnap_cron_hour }}"
-    day: "{{ tarsnap_cron_day }}"
-    month: "{{ tarsnap_cron_month }}"

--- a/tasks/tarsnapper.yml
+++ b/tasks/tarsnapper.yml
@@ -1,0 +1,24 @@
+- name: Install tarsnapper wrapper
+  easy_install: name=tarsnapper
+
+- name: Install tarsnapper configuration file
+  copy: src={{ tarsnap_tarsnapper_conf }} dest=/root/tarsnapper.conf mode=644
+
+- name: Install Tarsnap configuration file
+  template: src=tarsnaprc.j2 dest=/root/.tarsnaprc mode=644
+
+- name: Install tarsnapper backup script
+  copy: src=tarsnap.sh dest=/root/tarsnap.sh mode=755
+
+- name: Configure tarsnap logrotate
+  copy: src=etc_logrotate_tarsnap dest=/etc/logrotate.d/tarsnap owner=root group=root mode=0644
+
+- name: Install nightly Tarsnap-generations cronjob
+  cron:
+  args:
+    name: "Tarsnap backup"
+    job: "/root/tarsnap.sh > /dev/null"
+    minute: "{{ tarsnap_cron_minute }}"
+    hour: "{{ tarsnap_cron_hour }}"
+    day: "{{ tarsnap_cron_day }}"
+    month: "{{ tarsnap_cron_month }}"


### PR DESCRIPTION
A small feature I need: if `tarsnap_tarsnapper_conf` is falsy don't install tarsnapper nor cron job. 
