### PR TITLE
Fix possible typo - 'tarnsap' vs 'tarsnap'

### DIFF
--- a/tasks/tarsnap.yml
+++ b/tasks/tarsnap.yml
@@ -14,30 +14,30 @@
 
 - name: Check if tarsnap {{ tarsnap_version }} is installed
   shell: tarsnap --version | grep {{ tarsnap_version }} --color=never
-  register: tarnsap_installed
-  changed_when: "tarnsap_installed.stderr != ''"
+  register: tarsnap_installed
+  changed_when: "tarsnap_installed.stderr != ''"
   ignore_errors: yes
 
 - name: Download the current tarsnap code signing key
-  when: tarnsap_installed|failed
+  when: tarsnap_installed|failed
   get_url:
     url=https://www.tarsnap.com/tarsnap-signing-key.asc
     dest=/root/tarsnap-signing-key.asc
 
 - name: Add the tarsnap code signing key to your list of keys
-  when: tarnsap_installed|failed
+  when: tarsnap_installed|failed
   command:
     gpg --import tarsnap-signing-key.asc
     chdir=/root/
 
 - name: Download tarsnap SHA file
-  when: tarnsap_installed|failed
+  when: tarsnap_installed|failed
   get_url:
     url="https://www.tarsnap.com/download/tarsnap-sigs-{{ tarsnap_version }}.asc"
     dest="/root/tarsnap-sigs-{{ tarsnap_version }}.asc"
 
 - name: get the SHA256sum for this tarsnap release
-  when: tarnsap_installed|failed
+  when: tarsnap_installed|failed
   shell: >
     gpgResult=`gpg --decrypt tarsnap-sigs-{{ tarsnap_version }}.asc 2>/dev/null`;
     echo ${gpgResult#*=};
@@ -47,22 +47,22 @@
   register: tarsnap_sha
 
 - name: Download Tarsnap source
-  when: tarnsap_installed|failed
+  when: tarsnap_installed|failed
   get_url:
     url="https://www.tarsnap.com/download/tarsnap-autoconf-{{ tarsnap_version }}.tgz"
     dest="/root/tarsnap-autoconf-{{ tarsnap_version }}.tgz"
     sha256sum={{ tarsnap_sha.stdout_lines[0] }}
 
 - name: Decompress Tarsnap source
-  when: tarnsap_installed|failed
+  when: tarsnap_installed|failed
   command: tar xzf /root/tarsnap-autoconf-{{ tarsnap_version }}.tgz chdir=/root creates=/root/tarsnap-autoconf-{{ tarsnap_version }}/COPYING
 
 - name: Configure Tarsnap for local build
-  when: tarnsap_installed|failed
+  when: tarsnap_installed|failed
   command: ./configure chdir=/root/tarsnap-autoconf-{{ tarsnap_version }} creates=/root/tarsnap-autoconf-{{ tarsnap_version }}/Makefile
 
 - name: Build and install Tarsnap
-  when: tarnsap_installed|failed
+  when: tarsnap_installed|failed
   command: make all install clean chdir=/root/tarsnap-autoconf-{{ tarsnap_version }} creates=/usr/local/bin/tarsnap
 
 - name: Create Tarsnap cache directory


### PR DESCRIPTION
Hi!

Low-importance PR here as playbook works beautifully (thanks!). I was just modifying the role for my own purposes and noticed a potential typo ("tarnsap_installed") that caused me a bit of a headache when trying to add some additional tasks.

Functionality should be unchanged by this PR.

Cheers :smile: 
