### PR TITLE
Add leading zeros to octal permissions

### DIFF
--- a/tasks/tarsnap.yml
+++ b/tasks/tarsnap.yml
@@ -72,13 +72,13 @@
   easy_install: name=tarsnapper
 
 - name: Install tarsnapper configuration file
-  copy: src={{ tarsnap_tarsnapper_conf }} dest=/root/tarsnapper.conf mode=644
+  copy: src={{ tarsnap_tarsnapper_conf }} dest=/root/tarsnapper.conf mode=0644
 
 - name: Install Tarsnap configuration file
-  template: src=tarsnaprc.j2 dest=/root/.tarsnaprc mode=644
+  template: src=tarsnaprc.j2 dest=/root/.tarsnaprc mode=0644
 
 - name: Install tarsnapper backup script
-  copy: src=tarsnap.sh dest=/root/tarsnap.sh mode=755
+  copy: src=tarsnap.sh dest=/root/tarsnap.sh mode=0755
 
 - name: Configure tarsnap logrotate
   copy: src=etc_logrotate_tarsnap dest=/etc/logrotate.d/tarsnap owner=root group=root mode=0644


### PR DESCRIPTION
Fixes instances of `ANSIBLE0009 Octal file permissions must contain
leading zero` warning.
