### PR TITLE
Switch from "sudo: yes" to "become: true"

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -1,6 +1,6 @@
 - hosts: localhost
   connection: local
-  sudo: yes
+  become: true
   vars_files:
     - personal/defaults.yml
   roles:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: role for operating tarsnap backups
   company: "N/A"
   license: "GPL v3"
-  min_ansible_version: 1.7
+  min_ansible_version: 2.0
   platforms:
   - name: Debian
     versions:

--- a/tests/travis.yml
+++ b/tests/travis.yml
@@ -1,5 +1,5 @@
 - hosts: localhost
   connection: local
-  sudo: yes
+  become: true
   roles:
     - ansible-tarsnap

--- a/tests/vagrant.yml
+++ b/tests/vagrant.yml
@@ -1,5 +1,5 @@
 - hosts: all
-  sudo: yes
+  become: true
   pre_tasks:
     - name: Update apt cache
       apt: update_cache=yes


### PR DESCRIPTION
This fixes `[ANSIBLE0008] deprecated sudo feature` linting warnings and makes plays use Ansible's current privilege-escalation mechanism.

https://docs.ansible.com/ansible/become.html
