### PR TITLE
Replace "command" module running `tar` with "unarchive" module

### DIFF
--- a/tasks/tarsnap.yml
+++ b/tasks/tarsnap.yml
@@ -55,7 +55,11 @@
 
 - name: Decompress Tarsnap source
   when: tarnsap_installed|failed
-  command: tar xzf /root/tarsnap-autoconf-{{ tarsnap_version }}.tgz chdir=/root creates=/root/tarsnap-autoconf-{{ tarsnap_version }}/COPYING
+  unarchive:
+    src=/root/tarsnap-autoconf-{{ tarsnap_version }}.tgz
+    copy=no
+    dest=/root
+    creates=/root/tarsnap-autoconf-{{ tarsnap_version }}/COPYING
 
 - name: Configure Tarsnap for local build
   when: tarnsap_installed|failed


### PR DESCRIPTION
This fixes the `ANSIBLE0006 tar used in place of unarchive module`
lint warning in `Task/Handler: Decompress Tarsnap source`.
